### PR TITLE
ryuto_role_functions

### DIFF
--- a/suki-yaki/bodyguard.py
+++ b/suki-yaki/bodyguard.py
@@ -51,5 +51,5 @@ class SampleBodyguard(SampleVillager):
             candidates = self.get_alive_others(self.game_info.agent_list)
         # Update a guard candidate if the candidate is changed.
         if self.to_be_guarded == AGENT_NONE or self.to_be_guarded not in candidates:
-            self.to_be_guarded = self.random_select(candidates)
+            self.to_be_guarded = self.prob["SEER"].idxmax()
         return self.to_be_guarded if self.to_be_guarded != AGENT_NONE else self.me

--- a/suki-yaki/possessed.py
+++ b/suki-yaki/possessed.py
@@ -124,7 +124,7 @@ class SamplePossessed(SampleVillager):
             candidates = self.get_alive_others(self.game_info.agent_list)
         # Declare which to vote for if not declare yet or the candidate is changed.
         if self.vote_candidate == AGENT_NONE or self.vote_candidate not in candidates:
-            self.vote_candidate = self.random_select(candidates)
+            self.vote_candidate = self.prob["WEREWOLF"].idxmin()
             if self.vote_candidate != AGENT_NONE:
                 return Content(VoteContentBuilder(self.vote_candidate))
         return CONTENT_SKIP

--- a/suki-yaki/villager.py
+++ b/suki-yaki/villager.py
@@ -132,12 +132,24 @@ class SampleVillager(AbstractPlayer):
         self.game_setting = game_setting
         self.me = game_info.me
         if len(self.game_info.agent_list) == 5:
-            self.role_list = ["VILLAGER", "VILLAGER", "SEER", "POSESSED", "WEREWOLF"]
+            self.role_list = ["VILLAGER", "VILLAGER", "SEER", "POSSESSED", "WEREWOLF"]
+            if self.me == "VILLAGER":
+                self.role_list.pop(0)
+            else:
+                self.role_list = [role for role in self.role_list if role != self.me]
+            self.prob = pd.DataFrame(index=self.game_info.agent_list, columns=self.role_list, dtype=float)
+            self.prob[:] = 1.0/4
         else:
-            self.role_list = []
+            self.role_list = ["VILLAGER", "VILLAGER","VILLAGER","VILLAGER","VILLAGER","VILLAGER","VILLAGER","VILLAGER","SEER", "MEDIUM", "BODYGUARD", "WEREWOLF", "WEREWOLF", "WEREWOLF", "POSSESSED"]
+            if self.me == "VILLAGER":
+                self.role_list.pop(0)
+            elif self.me == "WEREWOLF":
+                self.role_list.pop(-1) 
+            else:
+                self.role_list = [role for role in self.role_list if role != self.me]
+            self.prob = pd.DataFrame(index=self.game_info.agent_list, columns=self.role_list, dtype=float)
+            self.prob[:] = 1.0/14
         logger.debug(f'index  {game_info.agent_list}')
-        self.prob = pd.DataFrame(index=self.game_info.agent_list, columns=self.role_list, dtype=float)
-        self.prob[:] = 0.2
         # Clear fields not to bring in information from the last game.
         self.comingout_map.clear()
         self.divination_reports.clear()
@@ -151,8 +163,6 @@ class SampleVillager(AbstractPlayer):
                 self.prob += self.prob.loc[agent] / (len(self.prob) - 1)
                 self.prob = self.prob.drop(agent)
             
-        
-
     def update(self, game_info: GameInfo) -> None:
         self.game_info = game_info  # Update game information.
         logger.debug('update')

--- a/suki-yaki/werewolf.py
+++ b/suki-yaki/werewolf.py
@@ -47,6 +47,14 @@ class SampleWerewolf(SamplePossessed):
         super().initialize(game_info, game_setting)
         self.allies = list(self.game_info.role_map.keys())
         self.humans = [a for a in self.game_info.agent_list if a not in self.allies]
+        for ally in self.allies:
+            self.prob.at[ally, "WEREWOLF"] = 0.5
+            for role in self.role_list:
+                if role != "WEREWOLF":
+                    self.prob.at[ally, role] = 0
+        for human in self.humans:
+            self.prob += 1.0 / 12 # WEREWOLFの確率を他の役職に平等に足した
+            self.prob.at[human, "WEREWOLF"] = 0
         # Do comingout on the day that randomly selected from the 1st, 2nd and 3rd day.
         self.co_date = random.randint(1, 3)
         # Choose fake role randomly.
@@ -91,7 +99,7 @@ class SampleWerewolf(SamplePossessed):
             candidates = self.get_alive(self.humans)
         # Declare which to vote for if not declare yet or the candidate is changed.
         if self.attack_vote_candidate == AGENT_NONE or self.attack_vote_candidate not in candidates:
-            self.attack_vote_candidate = self.random_select(candidates)
+            self.attack_vote_candidate = self.prob["POSSESSED"].idxmin()
             if self.attack_vote_candidate != AGENT_NONE:
                 return Content(AttackContentBuilder(self.attack_vote_candidate))
         return CONTENT_SKIP


### PR DESCRIPTION
変更点
確率の初期化で自分の役職の確率の削除。
bodyguard: 守る人を占い師の確率が最も高い人とした
possessed: 投票する人を人狼の確率が最も低い人とした
werewolf:
味方の人狼確率0.5ずつ、他を0とした
人間の人狼確率を0とし、他の役職に平等に確率を割り振った。